### PR TITLE
Bug fix - project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ Licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) Lice
 
 ## Changelog
 
--   **1.0.1**
-
-    Add function that user can choose project id where need to run integration, Rename params from metric_types to telemetry_list
-
--   **1.0.0**
-
-    Initial Release
+- **1.0.3**:
+    - **Bug fix** for project id's with more than 2 digits.
+- **1.0.1**:
+    - Add function that user can choose project id where need to run integration, Rename params from metric_types to telemetry_list
+- **1.0.0**:
+    - Initial Release

--- a/run.sh
+++ b/run.sh
@@ -441,7 +441,7 @@ function _choose_and_set_project_id(){
         echo "[$count]:  $project"
         array_projects+=("$project")
     done
-    read -n 2 -p "Please specify the project for integration deployment by referring to the project's numerical position in the list: " mainmenuinput
+    read -p "Please specify the project for integration deployment by referring to the project's numerical position in the list: " mainmenuinput
     count_projects=0
     for value in "${array_projects[@]}"
     do


### PR DESCRIPTION
Currently, if a project id is a number with over 2 digits, the script will only truncate the first to digits. This should fix it.